### PR TITLE
install-config-glance.xml: 'admin_password =' should not be the admin token in glance-api-paste.ini

### DIFF
--- a/doc/src/docbkx/openstack-install/install-config-glance.xml
+++ b/doc/src/docbkx/openstack-install/install-config-glance.xml
@@ -32,7 +32,7 @@
            <screen>[filter:authtoken]
 admin_tenant_name = service
 admin_user = glance
-admin_password = 012345SECRET99TOKEN012345</screen>
+admin_password = glance</screen>
         <para>Ensure that the glance-api pipeline section includes
             authtoken:</para>
            <screen>[pipeline:glance-api]


### PR DESCRIPTION
I believe the 'admin_password =' in the '[filter:authtoken] section of /etc/glance/glance-api-paste.ini should use the glance user password and not the admin token. Just as in the  [filter:authtoken] section of /etc/glance/glance-registry-paste.ini.
