### PR TITLE
fixed erroneous -s in nova sec-group-add-rule

### DIFF
--- a/doc/src/docbkx/openstack-compute-admin/computenetworking.xml
+++ b/doc/src/docbkx/openstack-compute-admin/computenetworking.xml
@@ -845,8 +845,8 @@ force_dhcp_release
         </note>
         <para>Using the nova command-line tool:</para>
         <screen>
-<prompt>$</prompt> <userinput>nova secgroup-add-rule default icmp -1 -1 -s 0.0.0.0/0</userinput>
-<prompt>$</prompt> <userinput>nova secgroup-add-rule default tcp 22 22 -s 0.0.0.0/0</userinput>
+<prompt>$</prompt> <userinput>nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0</userinput>
+<prompt>$</prompt> <userinput>nova secgroup-add-rule default tcp 22 22 0.0.0.0/0</userinput>
             </screen>
         <para>Using euca2ools:</para>
         <screen>


### PR DESCRIPTION
minor bug fix, nova-sec-group-add-rule doesn't use a -s.
