### PR TITLE
Fixed bad link for TryStack

### DIFF
--- a/www/trunk/index.html
+++ b/www/trunk/index.html
@@ -144,7 +144,7 @@
 		<div class="span-12">	
 		<h2><a href="http://openstack.org/software/start/">Getting Started</a>
 		</h2>	
-		<p>Get up and running quickly with <a href="http://devstack.org">DevStack</a>, <a href="http://trystack.org>">TryStack</a>, or all-in-one installation guides.
+		<p>Get up and running quickly with <a href="http://devstack.org">DevStack</a>, <a href="http://trystack.org">TryStack</a>, or all-in-one installation guides.
 		</p>
 		<h2><a href="/install/">Installing OpenStack</a>
 		</h2>


### PR DESCRIPTION
Removed an extra bracket so that the link to TryStack now works.
