### PR TITLE
Changed glance ini config to use glance user

### DIFF
--- a/doc/src/docbkx/openstack-install/ap_installingfolsom.xml
+++ b/doc/src/docbkx/openstack-install/ap_installingfolsom.xml
@@ -306,7 +306,7 @@ auth_host = 10.211.55.20
 auth_port = 35357
 auth_protocol = http
 admin_tenant_name = service
-admin_user = admin
+admin_user = glance
 admin_password = openstack</programlisting>Edit
             /etc/glance/glance-registry-paste.ini (filter
             authtoken).<programlisting>[filter:authtoken]
@@ -315,7 +315,7 @@ auth_host = 10.211.55.20
 auth_port = 35357
 auth_protocol = http
 admin_tenant_name = service
-admin_user = admin
+admin_user = glance
 admin_password = openstack</programlisting>
             Edit /etc/glance/glance-api.conf.</para>
         <para>SQLAlchemy part of


### PR DESCRIPTION
The original document used the admin user in the two glance ini files, which results in a keystone failure due to an invalid tenant. Using the glance user resolves this.
