### PR TITLE
Fixing typo found during translation (harware -> hardware).

### DIFF
--- a/doc/src/docbkx/openstack-install/compute-sys-requirements.xml
+++ b/doc/src/docbkx/openstack-install/compute-sys-requirements.xml
@@ -63,7 +63,7 @@
                         xlink:href="http://docs.vmd.citrix.com/XenServer/6.0.0/1.0/en_gb/installation.html#sys_requirements">
                         XenServer installation guide</link> and the <link
                         xlink:href="http://hcl.vmd.citrix.com/">
-                        XenServer harware compatibility list</link>.</para>
+                        XenServer hardware compatibility list</link>.</para>
                     <para>For LXC, the VT extensions are not required.</para>
                 </td>
             </tr>


### PR DESCRIPTION
Just a misspelled word.
