### PR TITLE
Replace rabbit_notifier with rpc_notifier

### DIFF
--- a/doc/install-guide/section_neutron-single-flat.xml
+++ b/doc/install-guide/section_neutron-single-flat.xml
@@ -172,7 +172,7 @@ core_plugin = neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
 control_exchange = neutron
 rabbit_host = <replaceable>controller</replaceable>
 rabbit_password = <replaceable>RABBIT_PASS</replaceable>
-notification_driver = neutron.openstack.common.notifier.rabbit_notifier
+notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 [database]
 connection = mysql://neutron:<replaceable>NEUTRON_DBPASS</replaceable>@<replaceable>controller</replaceable>/neutron
@@ -250,7 +250,7 @@ core_plugin = neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
 control_exchange = neutron
 rabbit_host = <replaceable>controller</replaceable>
 rabbit_password = <replaceable>RABBIT_PASS</replaceable>
-notification_driver = neutron.openstack.common.notifier.rabbit_notifier
+notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 [database]
 connection = mysql://neutron:<replaceable>NEUTRON_DBPASS</replaceable>@<replaceable>controller</replaceable>/neutron
@@ -298,7 +298,7 @@ core_plugin = neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2
 control_exchange = neutron
 rabbit_host = <replaceable>controller</replaceable>
 rabbit_password = <replaceable>RABBIT_PASS</replaceable>
-notification_driver = neutron.openstack.common.notifier.rabbit_notifier</programlisting>
+notification_driver = neutron.openstack.common.notifier.rpc_notifier</programlisting>
                         </listitem>
                         <listitem>
                             <para>Update the DHCP <filename>


### PR DESCRIPTION
See https://bugs.launchpad.net/oslo/+bug/1047019
e.g. rpc_notifier is the default option after installing in Ubuntu Precise so seeing rabbit_notifier in docs may mislead users.
