### PR TITLE
Update section_nova-controller-install.xml

### DIFF
--- a/doc/install-guide/section_nova-controller-install.xml
+++ b/doc/install-guide/section_nova-controller-install.xml
@@ -199,6 +199,13 @@ verbose = True</programlisting>
       </substeps>
     </step>
     <step>
+      <para>Configure password for the guest user in RabbitMQ:</para>
+      <screen><prompt>#</prompt> <userinput>rabbitmqctl change_password guest <replaceable>NOVA_DBPASS</replaceable></userinput></screen>
+      <para>Replace <replaceable>RABBIT_PASS</replaceable> with the
+            password you chose for the <literal>guest</literal> account in
+            <application>RabbitMQ</application>.</para>
+    </step>
+    <step>
       <para>Populate the Compute database:</para>
       <screen><prompt>#</prompt> <userinput>su -s /bin/sh -c "nova-manage db sync" nova</userinput></screen>
     </step>


### PR DESCRIPTION
The guide is missing the command to set the password for the RabbitMQ guest user. Therefor all services using that service will fail to connect.
