### PR TITLE
The CDFS (.iso) is ISO 9660, not 9960.

### DIFF
--- a/doc/glossary/glossary-terms.xml
+++ b/doc/glossary/glossary-terms.xml
@@ -4827,9 +4827,9 @@
     </glossentry>
 
     <glossentry>
-      <glossterm>ISO9960</glossterm>
+      <glossterm>ISO9660</glossterm>
       <indexterm class="singular">
-          <primary>ISO9960 format</primary>
+          <primary>ISO9660 format</primary>
         </indexterm>
 
       <glossdef>


### PR DESCRIPTION
Essentially a typo fix.