### PR TITLE
Resolv package name error

### DIFF
--- a/doc/config-reference/object-storage/section_configure_s3.xml
+++ b/doc/config-reference/object-storage/section_configure_s3.xml
@@ -46,7 +46,7 @@
     <screen><prompt>#</prompt> <userinput>python setup.py install</userinput></screen>
     <para>Alternatively, if you have configured the Ubuntu Cloud
         Archive, you may use:
-        <screen><prompt>#</prompt> <userinput>apt-get install swift-python-s3</userinput></screen></para>
+        <screen><prompt>#</prompt> <userinput>apt-get install swift-plugin-s3</userinput></screen></para>
     <para>To add this middleware to your configuration, add the <systemitem>swift3</systemitem>
         middleware in front of the <systemitem>swauth</systemitem> middleware, and before any other
         middleware that looks at Object Storage requests (like rate limiting).</para>


### PR DESCRIPTION
The cloudarchive-juno on ubuntu 14.04 is: 
deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/juno main
When install swift3 middleware using `apt-get install swift-python-s3` has an error:
```
E: Unable to locate package swift-python-s3
```
Because there is no `swift-python-s3` package, the package name is `swift-plugin-s3`.