### PR TITLE
p_api-ip changed to vip

### DIFF
--- a/doc/ha-guide/source/controller-ha-haproxy.rst
+++ b/doc/ha-guide/source/controller-ha-haproxy.rst
@@ -42,8 +42,8 @@ and ensure the VIPs can only run on machines where HAProxy is active:
 .. code-block:: console
 
    $ pcs resource create lb-haproxy systemd:haproxy --clone
-   $ pcs constraint order start p_api-ip then lb-haproxy-clone kind=Optional
-   $ pcs constraint colocation add p_api-ip with lb-haproxy-clone
+   $ pcs constraint order start vip then lb-haproxy-clone kind=Optional
+   $ pcs constraint colocation add vip with lb-haproxy-clone
 
 ``crmsh``
 


### PR DESCRIPTION
from previous steps the virtual ip name should be vip
https://bugs.launchpad.net/openstack-manuals/+bug/1592838