### PR TITLE
Fix typo in glance property key 'hypervisor-type'

### DIFF
--- a/doc/cli-reference/source/glance_property_keys.rst
+++ b/doc/cli-reference/source/glance_property_keys.rst
@@ -88,7 +88,7 @@ For example:
        * xtensaeb - `Tensilica Xtensa configurable microprocessor core
          <http://en.wikipedia.org/wiki/Xtensa#Processor_Cores>`_ (Big Endian)
    * - All
-     - ``hypervisor-type``
+     - ``hypervisor_type``
      - The hypervisor type. Note that ``qemu`` is used for both QEMU and KVM
        hypervisor types.
      - ``hyperv``, ``ironic``, ``lxc``, ``qemu``, ``uml``, ``vmware``, or


### PR DESCRIPTION
- 'hypervisor-type' is not a valid glance property key.
  Valid property key is 'hypervisor_type'